### PR TITLE
[aws] Encrypt root block device

### DIFF
--- a/terraform/platforms/aws/asg.tf
+++ b/terraform/platforms/aws/asg.tf
@@ -75,6 +75,7 @@ resource "aws_launch_configuration" "main" {
   root_block_device {
     volume_type = "gp2"
     volume_size = "${var.instance_disk_size}"
+    encrypted   = true
   }
 
   lifecycle {


### PR DESCRIPTION
Should I make this configurable? (I'd rather have encryption forced on)