### PR TITLE
terraform/modules/tls/tls.tf: ignore validity change by default

### DIFF
--- a/terraform/modules/tls/tls.tf
+++ b/terraform/modules/tls/tls.tf
@@ -39,6 +39,10 @@ resource "tls_self_signed_cert" "ca" {
     "digital_signature",
     "cert_signing",
   ]
+
+  lifecycle {
+    ignore_changes = ["validity_period_hours"]
+  }
 }
 
 locals {
@@ -84,6 +88,10 @@ resource "tls_locally_signed_cert" "clients-server" {
     "client_auth",
     "server_auth",
   ]
+
+  lifecycle {
+    ignore_changes = ["validity_period_hours"]
+  }
 }
 
 # Certificates for the etcd clients.
@@ -120,4 +128,8 @@ resource "tls_locally_signed_cert" "clients" {
     "key_encipherment",
     "client_auth",
   ]
+
+  lifecycle {
+    ignore_changes = ["validity_period_hours"]
+  }
 }


### PR DESCRIPTION
Actually felt bad pushing a certificate change to existing ECO users for a validity duration increase in https://github.com/Quentin-M/etcd-cloud-operator/pull/34. I suggest here adding an ignore on that particular field change, to avoid re-creating certs in the next plan, except if the certs are actually about to expire (and then renew them for 5y). 

It might actually be a positive thing to prompt users to re-do their certs with longer longevity earlier rather than rather (e.g. after they have expired if folks don't run the Terraform too often to notice the required renewal).

/cc @captn3m0 for thoughts