### PR TITLE
t/p/aws/asg.tf: adding support for aws v2.0.0

### DIFF
--- a/terraform/platforms/aws/asg.tf
+++ b/terraform/platforms/aws/asg.tf
@@ -34,6 +34,8 @@ data "aws_ami" "coreos" {
     name   = "owner-id"
     values = ["595879546273"]
   }
+
+  owners = ["595879546273"]
 }
 
 data "ignition_config" "s3" {


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#200-february-27-2019

AWS released their v2.0.0 breaking change that includes a change to the aws_ami data resource:

```
data-source/aws_ami_ids: Require owners argument (#5576)
```