### PR TITLE
e/terraform/m/i/r/eco-health.sh: fix condition for newer versions of etcdctl

### DIFF
--- a/terraform/modules/ignition/resources/eco-health.sh
+++ b/terraform/modules/ignition/resources/eco-health.sh
@@ -5,7 +5,7 @@ IP=$(/usr/bin/ip -4 addr show ${NIC} | /usr/bin/grep -oP '(?<=inet\s)\d+(\.\d+){
 
 i=0
 while true; do
-    /opt/bin/e --endpoints=${IP}:2379 endpoint --dial-timeout=500ms --command-timeout=500ms health | grep "successfully" 2>&1 > /dev/null
+    /opt/bin/e --endpoints=${IP}:2379 endpoint --dial-timeout=500ms --command-timeout=500ms health 2>&1 | grep "successfully" > /dev/null
     if [ $? -eq 0 ]; then
         echo "ECO is healthy"
         i=0


### PR DESCRIPTION
old behavior:

```
core ~ $ /opt/bin/e --endpoints=${IP}:2379 endpoint --dial-timeout=500ms --command-timeout=500ms health
<redacted>:2379 is healthy: successfully committed proposal: took = 1.079552ms

core ~ $ /opt/bin/e --endpoints=${IP}:2379 endpoint --dial-timeout=500ms --command-timeout=500ms health | grep "successfully" 2>&1 > /dev/null
core ~ $ echo $?
0
```

new behavior:
```
core ~ $ /opt/bin/e --endpoints=${IP}:2379 endpoint --dial-timeout=500ms --command-timeout=500ms health | grep "successfully" 2>&1 > /dev/null
<redacted>:2379 is healthy: successfully committed proposal: took = 8.815389ms
core ~ $ echo $?
1
```