### PR TITLE
document ECO abbreviation

### DIFF
--- a/terraform/platforms/aws/README.md
+++ b/terraform/platforms/aws/README.md
@@ -17,7 +17,8 @@ terraform apply .
 ```
 
 A Terraform configuration file (terraform/platforms/aws/terraform.tfvars) should
-then be created. Note that all available ECO configuration knobs are not exposed.
+then be created. Note that all available ectd-cloud-operator (ECO) configuration
+knobs are not exposed.
 
 ```
 # Name of the deployment.


### PR DESCRIPTION
Perhaps was just being silly, but thought "ECO" was some sort of supporting service for coreos/ignition (which I haven't used before) spent 10 min googling before hitting on the obvious. Small doc change to make that a bit less likely for those who similarly need more caffeine.