### PR TITLE
terraform/common.tf: Enforce string type for some boolean values

### DIFF
--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -40,11 +40,12 @@ variable "eco_image" {
 
 variable "eco_enable_tls" {
   description = "Defines whether etcd should expect TLS clients connections"
-  default     = true
+  default     = "true"
 }
 
 variable "eco_require_client_certs" {
   description = "Defines whether etcd should expect client certificates for client connections"
+  default     = "false"
 }
 
 variable "eco_snapshot_interval" {
@@ -93,9 +94,9 @@ module "configuration" {
   eco_advertise_address    = local.advertise_address
   eco_snapshot_bucket      = local.snapshot_bucket
 
-  eco_ca_file             = var.eco_enable_tls == true ? module.ignition.eco_ca_file : ""
-  eco_cert_file           = var.eco_enable_tls == true ? module.ignition.eco_cert_file : ""
-  eco_key_file            = var.eco_enable_tls == true ? module.ignition.eco_key_file : ""
+  eco_ca_file             = var.eco_enable_tls == "true" ? module.ignition.eco_ca_file : ""
+  eco_cert_file           = var.eco_enable_tls == "true" ? module.ignition.eco_cert_file : ""
+  eco_key_file            = var.eco_enable_tls == "true" ? module.ignition.eco_key_file : ""
   eco_require_client_cert = var.eco_require_client_certs
 
   eco_snapshot_interval = var.eco_snapshot_interval

--- a/terraform/extra/aws_network/output.tf
+++ b/terraform/extra/aws_network/output.tf
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 output "vpc_id" {
-  value = "${aws_vpc.main.id}"
+  value = aws_vpc.main.id
 }
 
 output "public_subnets_ids" {
-  value = ["${aws_subnet.public.*.id}"]
+  value = [aws_subnet.public.*.id]
 }
+

--- a/terraform/extra/aws_network/variables.tf
+++ b/terraform/extra/aws_network/variables.tf
@@ -15,3 +15,4 @@
 variable "name" {
   description = "Name of the deployment"
 }
+

--- a/terraform/extra/aws_network/versions.tf
+++ b/terraform/extra/aws_network/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/tls/output.tf
+++ b/terraform/modules/tls/output.tf
@@ -13,22 +13,22 @@
 // limitations under the License.
 
 output "ca" {
-  value = var.enabled == true ? local.ca["cert"] : ""
+  value = var.enabled == "true" ? local.ca["cert"] : ""
 }
 
 output "clients_server_cert" {
-  value = var.enabled == true ? join("", tls_locally_signed_cert.clients-server.*.cert_pem) : ""
+  value = var.enabled == "true" ? join("", tls_locally_signed_cert.clients-server.*.cert_pem) : ""
 }
 
 output "clients_server_key" {
-  value = var.enabled == true ? join("", tls_private_key.clients-server.*.private_key_pem) : ""
+  value = var.enabled == "true" ? join("", tls_private_key.clients-server.*.private_key_pem) : ""
 }
 
 output "clients_cert" {
-  value = var.enabled == true && var.generate_clients_cert == true ? join("", tls_locally_signed_cert.clients.*.cert_pem) : ""
+  value = var.enabled == "true" && var.generate_clients_cert == "true" ? join("", tls_locally_signed_cert.clients.*.cert_pem) : ""
 }
 
 output "clients_key" {
-  value = var.enabled == true && var.generate_clients_cert == true ? join("", tls_private_key.clients.*.private_key_pem) : ""
+  value = var.enabled == "true" && var.generate_clients_cert == "true" ? join("", tls_private_key.clients.*.private_key_pem) : ""
 }
 

--- a/terraform/modules/tls/tls.tf
+++ b/terraform/modules/tls/tls.tf
@@ -15,14 +15,14 @@
 # CA.
 
 resource "tls_private_key" "ca" {
-  count = var.enabled == true && length(var.ca["key"]) == 0 ? 1 : 0
+  count = var.enabled == "true" && length(var.ca["key"]) == 0 ? 1 : 0
 
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_self_signed_cert" "ca" {
-  count = var.enabled == true && length(var.ca["key"]) == 0 ? 1 : 0
+  count = var.enabled == "true" && length(var.ca["key"]) == 0 ? 1 : 0
 
   key_algorithm         = tls_private_key.ca[0].algorithm
   private_key_pem       = tls_private_key.ca[0].private_key_pem
@@ -56,14 +56,14 @@ locals {
 # Certificate for the etcd client server.
 
 resource "tls_private_key" "clients-server" {
-  count = var.enabled == true ? 1 : 0
+  count = var.enabled == "true" ? 1 : 0
 
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_cert_request" "clients-server" {
-  count = var.enabled == true ? 1 : 0
+  count = var.enabled == "true" ? 1 : 0
 
   key_algorithm   = tls_private_key.clients-server[0].algorithm
   private_key_pem = tls_private_key.clients-server[0].private_key_pem
@@ -75,7 +75,7 @@ resource "tls_cert_request" "clients-server" {
 }
 
 resource "tls_locally_signed_cert" "clients-server" {
-  count = var.enabled == true ? 1 : 0
+  count = var.enabled == "true" ? 1 : 0
 
   cert_request_pem      = tls_cert_request.clients-server[0].cert_request_pem
   ca_key_algorithm      = local.ca["alg"]
@@ -97,14 +97,14 @@ resource "tls_locally_signed_cert" "clients-server" {
 # Certificates for the etcd clients.
 
 resource "tls_private_key" "clients" {
-  count = var.enabled == true && var.generate_clients_cert == true ? 1 : 0
+  count = var.enabled == "true" && var.generate_clients_cert == "true" ? 1 : 0
 
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_cert_request" "clients" {
-  count = var.enabled == true && var.generate_clients_cert == true ? 1 : 0
+  count = var.enabled == "true" && var.generate_clients_cert == "true" ? 1 : 0
 
   key_algorithm   = tls_private_key.clients[0].algorithm
   private_key_pem = tls_private_key.clients[0].private_key_pem
@@ -116,7 +116,7 @@ resource "tls_cert_request" "clients" {
 }
 
 resource "tls_locally_signed_cert" "clients" {
-  count = var.enabled == true && var.generate_clients_cert == true ? 1 : 0
+  count = var.enabled == "true" && var.generate_clients_cert == "true" ? 1 : 0
 
   cert_request_pem      = tls_cert_request.clients[0].cert_request_pem
   ca_key_algorithm      = local.ca["alg"]

--- a/terraform/platforms/aws/asg.tf
+++ b/terraform/platforms/aws/asg.tf
@@ -82,7 +82,7 @@ resource "aws_launch_configuration" "main" {
   security_groups      = [aws_security_group.instances.id]
   iam_instance_profile = aws_iam_instance_profile.instances.arn
   user_data            = data.ignition_config.s3.rendered
-  ebs_optimized        = "true"
+  ebs_optimized        = true
 
   associate_public_ip_address = var.associate_public_ips
 

--- a/terraform/platforms/aws/output.tf
+++ b/terraform/platforms/aws/output.tf
@@ -22,9 +22,10 @@ output "instance_security_group" {
 }
 
 output "lb_dns_name" {
-  value = "${aws_elb.clients.dns_name}"
+  value = aws_elb.clients.dns_name
 }
 
 output "lb_zone_id" {
-  value = "${aws_elb.clients.zone_id}"
+  value = aws_elb.clients.zone_id
 }
+

--- a/terraform/platforms/aws/output.tf
+++ b/terraform/platforms/aws/output.tf
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 output "etcd_address" {
-  value = "${var.eco_enable_tls == true ? "https" : "http"}://${var.route53_zone_id != "" ? join("", aws_route53_record.elb.*.name) : aws_elb.clients.dns_name}:2379"
+  value = "${var.eco_enable_tls == "true" ? "https" : "http"}://${var.route53_zone_id != "" ? join("", aws_route53_record.elb.*.name) : aws_elb.clients.dns_name}:2379"
 }
 
 // You can attach extra rules using aws_security_group_rule


### PR DESCRIPTION
This fixes a backward compatibility issue with 0.12 terraform where if
not specified explicitly, the "true" is not considered as boolean.

Without the change, eco_enable_tls = "true" is not the same as
eco_enable_tls = true, thus running the terraform apply with the new eco
module will delete the tls certs.

Alternatively, we should change all the types to boolean, but that will
cause some backward compatibility issue as mentioned above.