### PR TITLE
[DO NOT MERGE] terraform/*: Enforce boolean types for boolean values.

### DIFF
--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -40,12 +40,12 @@ variable "eco_image" {
 
 variable "eco_enable_tls" {
   description = "Defines whether etcd should expect TLS clients connections"
-  default     = "true"
+  default     = true
 }
 
 variable "eco_require_client_certs" {
   description = "Defines whether etcd should expect client certificates for client connections"
-  default     = "false"
+  default     = false
 }
 
 variable "eco_snapshot_interval" {
@@ -94,9 +94,9 @@ module "configuration" {
   eco_advertise_address    = local.advertise_address
   eco_snapshot_bucket      = local.snapshot_bucket
 
-  eco_ca_file             = var.eco_enable_tls == "true" ? module.ignition.eco_ca_file : ""
-  eco_cert_file           = var.eco_enable_tls == "true" ? module.ignition.eco_cert_file : ""
-  eco_key_file            = var.eco_enable_tls == "true" ? module.ignition.eco_key_file : ""
+  eco_ca_file             = var.eco_enable_tls == true ? module.ignition.eco_ca_file : ""
+  eco_cert_file           = var.eco_enable_tls == true ? module.ignition.eco_cert_file : ""
+  eco_key_file            = var.eco_enable_tls == true ? module.ignition.eco_key_file : ""
   eco_require_client_cert = var.eco_require_client_certs
 
   eco_snapshot_interval = var.eco_snapshot_interval

--- a/terraform/modules/tls/output.tf
+++ b/terraform/modules/tls/output.tf
@@ -13,22 +13,22 @@
 // limitations under the License.
 
 output "ca" {
-  value = var.enabled == "true" ? local.ca["cert"] : ""
+  value = var.enabled == true ? local.ca["cert"] : ""
 }
 
 output "clients_server_cert" {
-  value = var.enabled == "true" ? join("", tls_locally_signed_cert.clients-server.*.cert_pem) : ""
+  value = var.enabled == true ? join("", tls_locally_signed_cert.clients-server.*.cert_pem) : ""
 }
 
 output "clients_server_key" {
-  value = var.enabled == "true" ? join("", tls_private_key.clients-server.*.private_key_pem) : ""
+  value = var.enabled == true ? join("", tls_private_key.clients-server.*.private_key_pem) : ""
 }
 
 output "clients_cert" {
-  value = var.enabled == "true" && var.generate_clients_cert == "true" ? join("", tls_locally_signed_cert.clients.*.cert_pem) : ""
+  value = var.enabled == true && var.generate_clients_cert == true ? join("", tls_locally_signed_cert.clients.*.cert_pem) : ""
 }
 
 output "clients_key" {
-  value = var.enabled == "true" && var.generate_clients_cert == "true" ? join("", tls_private_key.clients.*.private_key_pem) : ""
+  value = var.enabled == true && var.generate_clients_cert == true ? join("", tls_private_key.clients.*.private_key_pem) : ""
 }
 

--- a/terraform/modules/tls/tls.tf
+++ b/terraform/modules/tls/tls.tf
@@ -15,14 +15,14 @@
 # CA.
 
 resource "tls_private_key" "ca" {
-  count = var.enabled == "true" && length(var.ca["key"]) == 0 ? 1 : 0
+  count = var.enabled == true && length(var.ca["key"]) == 0 ? 1 : 0
 
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_self_signed_cert" "ca" {
-  count = var.enabled == "true" && length(var.ca["key"]) == 0 ? 1 : 0
+  count = var.enabled == true && length(var.ca["key"]) == 0 ? 1 : 0
 
   key_algorithm         = tls_private_key.ca[0].algorithm
   private_key_pem       = tls_private_key.ca[0].private_key_pem
@@ -56,14 +56,14 @@ locals {
 # Certificate for the etcd client server.
 
 resource "tls_private_key" "clients-server" {
-  count = var.enabled == "true" ? 1 : 0
+  count = var.enabled == true ? 1 : 0
 
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_cert_request" "clients-server" {
-  count = var.enabled == "true" ? 1 : 0
+  count = var.enabled == true ? 1 : 0
 
   key_algorithm   = tls_private_key.clients-server[0].algorithm
   private_key_pem = tls_private_key.clients-server[0].private_key_pem
@@ -75,7 +75,7 @@ resource "tls_cert_request" "clients-server" {
 }
 
 resource "tls_locally_signed_cert" "clients-server" {
-  count = var.enabled == "true" ? 1 : 0
+  count = var.enabled == true ? 1 : 0
 
   cert_request_pem      = tls_cert_request.clients-server[0].cert_request_pem
   ca_key_algorithm      = local.ca["alg"]
@@ -97,14 +97,14 @@ resource "tls_locally_signed_cert" "clients-server" {
 # Certificates for the etcd clients.
 
 resource "tls_private_key" "clients" {
-  count = var.enabled == "true" && var.generate_clients_cert == "true" ? 1 : 0
+  count = var.enabled == true && var.generate_clients_cert == true ? 1 : 0
 
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_cert_request" "clients" {
-  count = var.enabled == "true" && var.generate_clients_cert == "true" ? 1 : 0
+  count = var.enabled == true && var.generate_clients_cert == true ? 1 : 0
 
   key_algorithm   = tls_private_key.clients[0].algorithm
   private_key_pem = tls_private_key.clients[0].private_key_pem
@@ -116,7 +116,7 @@ resource "tls_cert_request" "clients" {
 }
 
 resource "tls_locally_signed_cert" "clients" {
-  count = var.enabled == "true" && var.generate_clients_cert == "true" ? 1 : 0
+  count = var.enabled == true && var.generate_clients_cert == true ? 1 : 0
 
   cert_request_pem      = tls_cert_request.clients[0].cert_request_pem
   ca_key_algorithm      = local.ca["alg"]

--- a/terraform/platforms/aws/README.md
+++ b/terraform/platforms/aws/README.md
@@ -33,19 +33,19 @@ instance_disk_size = "30"
 instance_ssh_keys = ["ssh-rsa ..."]
 
 # Defines whether public IPs should be assigned to the EC2 instances (mainly depends if public or private subnets are used).
-associate_public_ips = "true"
+associate_public_ips = true
 # List of the subnet IDs to place the EC2 instances in (should span across AZs for availability).
 subnets_ids = ["subnet-f438f793", "subnet-d4bea38c"]
 # ID of the VPC where the subnets are defined.
 vpc_id = "vpc-19f019"
 # Defines whether a Route53 record should be created for client connections.
-route53_enabled = "false"
+route53_enabled = false
 # Optional Route53 Zone ID under which an 'etcd' record should be created for client connections.
 route53_zone_id = ""
 # Route53 prefix name defines the shortname for the record. Appends to route53_zone_id name for fqdn.
 route53_prefix = "" #Default = "etcd"
 # Defines whether the load balancer for etcd will be internet facing or internal.
-load_balancer_internal = "false"
+load_balancer_internal = false
 # List of the security group IDs to apply to the load balancer (ingress TCP 2379) (if empty, defaults to open to all).
 load_balancer_security_group_ids = []
 # List of the security group IDs authorized to reach etcd/node-exporter metrics using the internal instances' IPs (if empty, metrics are not exposed)
@@ -54,9 +54,9 @@ metrics_security_group_ids = []
 # Container image of ECO to use.
 eco_image = "qmachu/etcd-cloud-operator:v3.3.3"
 # Defines whether etcd should expect TLS clients connections.
-eco_enable_tls = "true"
+eco_enable_tls = true
 # Defines whether etcd should expect client certificates for client connections.
-eco_require_client_certs = "false"
+eco_require_client_certs = false
 # Defines the interval between consecutive etcd snapshots (e.g. 30m).
 eco_snapshot_interval = "30m"
 # Defines the lifespan of each etcd snapshot (e.g. 24h).
@@ -111,18 +111,18 @@ module "eco" {
   instance_disk_size    = "30"
   instance_ssh_keys     = ["ssh-rsa ..."]
 
-  associate_public_ip_address      = "true"
+  associate_public_ip_address      = true
   subnets_ids                      = ["subnet-f438f793", "subnet-d4bea38c"]
   vpc_id                           = "vpc-19f019"
-  route53_enabled                  = "false"
+  route53_enabled                  = false
   route53_zone_id                  = ""
-  load_balancer_internal           = "false"
+  load_balancer_internal           = false
   load_balancer_security_group_ids = []
   metrics_security_group_ids       = []
 
   eco_image                  = "qmachu/etcd-cloud-operator:v3.3.3"
-  eco_enable_tls             = "true"
-  eco_require_client_certs   = "false"
+  eco_enable_tls             = true
+  eco_require_client_certs   = false
   eco_snapshot_interval      = "30m"
   eco_snapshot_ttl           = "24h"
 

--- a/terraform/platforms/aws/aws.tf
+++ b/terraform/platforms/aws/aws.tf
@@ -87,6 +87,6 @@ locals {
   snapshot_provider    = "s3"
   unhealthy_member_ttl = "3m"
   snapshot_bucket      = aws_s3_bucket.backups.bucket
-  advertise_address    = var.route53_enabled == "true" ? join("", aws_route53_record.elb.*.name) : aws_elb.clients.dns_name
+  advertise_address    = var.route53_enabled == true ? join("", aws_route53_record.elb.*.name) : aws_elb.clients.dns_name
 }
 

--- a/terraform/platforms/aws/output.tf
+++ b/terraform/platforms/aws/output.tf
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 output "etcd_address" {
-  value = "${var.eco_enable_tls == "true" ? "https" : "http"}://${var.route53_zone_id != "" ? join("", aws_route53_record.elb.*.name) : aws_elb.clients.dns_name}:2379"
+  value = "${var.eco_enable_tls == true ? "https" : "http"}://${var.route53_zone_id != "" ? join("", aws_route53_record.elb.*.name) : aws_elb.clients.dns_name}:2379"
 }
 
 // You can attach extra rules using aws_security_group_rule

--- a/terraform/platforms/aws/route53.tf
+++ b/terraform/platforms/aws/route53.tf
@@ -1,11 +1,11 @@
 data "aws_route53_zone" "main" {
-  count = var.route53_enabled == "true" ? 1 : 0
+  count = var.route53_enabled == true ? 1 : 0
 
   zone_id = var.route53_zone_id
 }
 
 resource "aws_route53_record" "elb" {
-  count = var.route53_enabled == "true" ? 1 : 0
+  count = var.route53_enabled == true ? 1 : 0
 
   zone_id = data.aws_route53_zone.main[0].zone_id
   name    = "${var.route53_prefix}.${data.aws_route53_zone.main[0].name}"

--- a/terraform/platforms/aws/variables.tf
+++ b/terraform/platforms/aws/variables.tf
@@ -48,7 +48,7 @@ variable "route53_prefix" {
 
 variable "route53_enabled" {
   description = "Defines whether a Route53 record should be created for client connections"
-  default     = "false"
+  default     = false
 }
 
 variable "route53_zone_id" {


### PR DESCRIPTION
    This fixes a backward compatibility issue with 0.12 terraform where if
    not specified explicitly, the "true" is not considered as boolean.

    Without the change, eco_enable_tls = "true" is not the same as
    eco_enable_tls = true, thus running the terraform apply with the new eco
    module will delete the tls certs.

    Alternatively, we could change all the types to boolean, but that will
    cause some backward compatibility issue as mentioned above.