### PR TITLE
terraform/platforms/aws/aws.tf: always allow eco instances to reach the ELB

### DIFF
--- a/terraform/extra/aws_network/aws_network.tf
+++ b/terraform/extra/aws_network/aws_network.tf
@@ -16,7 +16,7 @@ data "aws_availability_zones" "azs" {
 }
 
 resource "aws_vpc" "main" {
-  cidr_block           = "172.16.0.0/16"
+  cidr_block           = var.cidr
   enable_dns_hostnames = true
   enable_dns_support   = true
 
@@ -65,4 +65,3 @@ resource "aws_route_table" "public" {
     "Name" = "${data.aws_availability_zones.azs.names[count.index]}.${var.name}"
   }
 }
-

--- a/terraform/extra/aws_network/variables.tf
+++ b/terraform/extra/aws_network/variables.tf
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 variable "name" {
-  description = "Name of the deployment"
+  description = "Name of the network"
 }
 
+variable "cidr" {
+  description = "CIDR of the network"
+  default = "172.16.0.0/16"
+}

--- a/terraform/platforms/aws/aws.tf
+++ b/terraform/platforms/aws/aws.tf
@@ -20,7 +20,7 @@ resource "aws_elb" "clients" {
 
   security_groups = split(
     ",",
-    length(var.load_balancer_security_group_ids) > 0 ? join(",", var.load_balancer_security_group_ids) : aws_security_group.elb.id,
+    length(var.load_balancer_security_group_ids) > 0 ? join(",", concat([aws_security_group.instances.id], var.load_balancer_security_group_ids)) : aws_security_group.elb.id,
   )
 
   cross_zone_load_balancing = true


### PR DESCRIPTION
Noticed etcd was complaining in the logs yesterday during a recovery - although it wasn't strictly needed for recovery as per past testing. Regardless, this can simplify some basic troubleshooting.

Syntax to be verified.