### PR TITLE
Terraform upgrade to version >= 0.13

### DIFF
--- a/terraform/extra/aws_network/versions.tf
+++ b/terraform/extra/aws_network/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/terraform/modules/ignition/versions.tf
+++ b/terraform/modules/ignition/versions.tf
@@ -1,7 +1,13 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
   required_providers {
-    ignition = "~> 1.2"
+    ignition = {
+      source  = "terraform-providers/ignition"
+      version = "~> 1.2"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
   }
 }

--- a/terraform/modules/tls/versions.tf
+++ b/terraform/modules/tls/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    tls = {
+      source = "hashicorp/tls"
+    }
+  }
 }

--- a/terraform/platforms/aws/versions.tf
+++ b/terraform/platforms/aws/versions.tf
@@ -1,4 +1,15 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    ignition = {
+      source = "terraform-providers/ignition"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
 }


### PR DESCRIPTION
Terraform modules on version >=0.13 that use ECO have a dependency on ECO to be on >=0.13 as well. 