### PR TITLE
Add dns_names to certs

### DIFF
--- a/terraform/modules/tls/tls.tf
+++ b/terraform/modules/tls/tls.tf
@@ -34,6 +34,8 @@ resource "tls_self_signed_cert" "ca" {
     organization = "etcd"
   }
 
+  dns_names = ["etcd"]
+
   allowed_uses = [
     "key_encipherment",
     "digital_signature",
@@ -72,6 +74,8 @@ resource "tls_cert_request" "clients-server" {
     common_name  = var.common_name
     organization = "etcd"
   }
+
+  dns_names = [var.common_name]
 }
 
 resource "tls_locally_signed_cert" "clients-server" {
@@ -113,6 +117,8 @@ resource "tls_cert_request" "clients" {
     common_name  = "etcd"
     organization = "etcd"
   }
+
+  dns_names = ["etcd"]
 }
 
 resource "tls_locally_signed_cert" "clients" {
@@ -153,6 +159,8 @@ resource "tls_cert_request" "acl_users" {
     common_name  = var.eco_init_acl_users[count.index].name
     organization = "etcd"
   }
+
+  dns_names = [var.eco_init_acl_users[count.index].name]
 }
 
 resource "tls_locally_signed_cert" "acl_users" {


### PR DESCRIPTION
To generate etcd certificates with Subject Alternative Names (SAN) field.

Go 1.15 deprecates legacy Common Name field in X.509 certificates. A certificate handshake lacking the proper SAN field will now fail by default, resulting in the following connection error in kube-apiserver v1.19+:

```
W0223 23:41:28.126612       1 clientconn.go:1223] grpc: addrConn.createTransport failed to connect to {https://etcd.k8s.xxxxxx.xxx:2379  <nil> 0 <nil>}. Err :connection error: desc = "transport: authentication handshake failed: x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0". Reconnecting...
```

For more information, see https://golang.org/doc/go1.15#commonname