### PR TITLE
pkg/*: Add support for jwt auth token in the ECO.

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -62,6 +62,14 @@ eco:
         password: foo # Password is optional.
         roles:
         - range-example-role
+
+    # Configuration for the jwt auth token (optional).
+    jwt-auth-token-config:
+      sign-method: RS512 # Default to 'RS512', (optional).
+      private-key-file: /etc/eco/eco-jwt-key.private
+      public-key-file: /etc/eco/eco-jwt-key.public
+      ttl: 10m # Default to '10m', (optional).
+      
   # Configuration of the auto-scaling group provider.
   asg:
     provider: aws

--- a/pkg/etcd/misc.go
+++ b/pkg/etcd/misc.go
@@ -40,14 +40,15 @@ const (
 // EtcdConfiguration contains the configuration related to the underlying etcd
 // server.
 type EtcdConfiguration struct {
-	AdvertiseAddress        string         `yaml:"advertise-address"`
-	DataDir                 string         `yaml:"data-dir"`
-	ClientTransportSecurity SecurityConfig `yaml:"client-transport-security"`
-	PeerTransportSecurity   SecurityConfig `yaml:"peer-transport-security"`
-	BackendQuota            int64          `yaml:"backend-quota"`
-	AutoCompactionMode      string         `yaml:"auto-compaction-mode"`
-	AutoCompactionRetention string         `yaml:"auto-compaction-retention"`
-	InitACL                 *ACLConfig     `yaml:"init-acl,omitempty"`
+	AdvertiseAddress        string              `yaml:"advertise-address"`
+	DataDir                 string              `yaml:"data-dir"`
+	ClientTransportSecurity SecurityConfig      `yaml:"client-transport-security"`
+	PeerTransportSecurity   SecurityConfig      `yaml:"peer-transport-security"`
+	BackendQuota            int64               `yaml:"backend-quota"`
+	AutoCompactionMode      string              `yaml:"auto-compaction-mode"`
+	AutoCompactionRetention string              `yaml:"auto-compaction-retention"`
+	InitACL                 *ACLConfig          `yaml:"init-acl,omitempty"`
+	JWTAuthTokenConfig      *JWTAuthTokenConfig `yaml:"jwt-auth-token-config,omitempty"`
 }
 
 type SecurityConfig struct {
@@ -65,6 +66,14 @@ type ACLConfig struct {
 	RootPassword *string `yaml:"rootPassword,omitempty"`
 	Roles        []Role  `yaml:"roles"`
 	Users        []User  `yaml:"users"`
+}
+
+// JWTAuthTokenConfig defines the config for the JWT auth token.
+type JWTAuthTokenConfig struct {
+	SignMethod     string `yaml:"sign-method"`
+	PrivateKeyFile string `yaml:"private-key-file"`
+	PublicKeyFile  string `yaml:"public-key-file"`
+	TTL            string `yaml:"ttl"`
 }
 
 // Role defines an etcd ACL role with its permissions.

--- a/pkg/operator/misc.go
+++ b/pkg/operator/misc.go
@@ -153,6 +153,7 @@ func serverConfig(cfg Config, asgSelf asg.Instance, snapshotProvider snapshot.Pr
 		SnapshotProvider:        snapshotProvider,
 		SnapshotInterval:        cfg.Snapshot.Interval,
 		SnapshotTTL:             cfg.Snapshot.TTL,
+		JWTAuthTokenConfig:      cfg.Etcd.JWTAuthTokenConfig,
 	}
 }
 

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -173,6 +173,20 @@ variable "eco_init_acl_users" {
   default = []
 }
 
+variable "enable_jwt_token" {
+  description = "Defines whether or not to create private/public key pairs to verify jwt tokens"
+  default     = false
+}
+
+variable "jwt_sign_method" {
+  description = "Defines the sign method of the jwt auth token (optional)"
+  default     = "RS512"
+}
+
+variable "jwt_ttl" {
+  description = "Defines the ttl of the jwt auth token(optional)"
+  default     = "10m"
+}
 
 // Modules.
 
@@ -185,6 +199,8 @@ module "tls" {
   generate_clients_cert = var.eco_require_client_certs
 
   eco_init_acl_users = var.eco_init_acl_users
+
+  enable_jwt_token = var.enable_jwt_token
 }
 
 module "configuration" {
@@ -215,6 +231,12 @@ module "configuration" {
   eco_init_acl_rootpw = var.eco_init_acl_rootpw
   eco_init_acl_roles  = var.eco_init_acl_roles
   eco_init_acl_users  = var.eco_init_acl_users
+
+  jwt_enabled          = var.enable_jwt_token
+  jwt_private_key_file = var.enable_jwt_token ? module.ignition.eco_jwt_private_key_file : ""
+  jwt_public_key_file  = var.enable_jwt_token ? module.ignition.eco_jwt_public_key_file : ""
+  jwt_sign_method      = var.jwt_sign_method
+  jwt_ttl              = var.jwt_ttl
 }
 
 module "ignition" {
@@ -232,6 +254,10 @@ module "ignition" {
   eco_ca   = module.tls.ca
 
   ignition_extra_config = var.ignition_extra_config
+
+  eco_jwt_enabled     = var.enable_jwt_token
+  eco_jwt_private_key = module.tls.jwt_private_key
+  eco_jwt_public_key  = module.tls.jwt_public_key
 }
 
 // Output.

--- a/terraform/extra/aws_network/variables.tf
+++ b/terraform/extra/aws_network/variables.tf
@@ -18,5 +18,5 @@ variable "name" {
 
 variable "cidr" {
   description = "CIDR of the network"
-  default = "172.16.0.0/16"
+  default     = "172.16.0.0/16"
 }

--- a/terraform/modules/configuration/configuration.tf
+++ b/terraform/modules/configuration/configuration.tf
@@ -60,6 +60,13 @@ eco:
 %{ endfor ~}
 %{ endfor ~}
 %{ endif ~}
+%{ if var.jwt_enabled ~}
+    jwt-auth-token-config:
+      sign-method: ${var.jwt_sign_method}
+      private-key-file: ${var.jwt_private_key_file}
+      public-key-file: ${var.jwt_public_key_file}
+      ttl: ${var.jwt_ttl}
+%{ endif ~}
   asg:
     provider: ${var.eco_asg_provider}
   snapshot:

--- a/terraform/modules/configuration/variables.tf
+++ b/terraform/modules/configuration/variables.tf
@@ -91,3 +91,24 @@ variable "eco_init_acl_roles" {
 variable "eco_init_acl_users" {
   description = "Defines the list of ACL users for the etcd (optional)"
 }
+
+variable "jwt_enabled" {
+  description = "Defines whether the jwt auth token is enabled"
+  default     = false
+}
+
+variable "jwt_sign_method" {
+  description = "Defines the sign method of the jwt auth token (optional)"
+}
+
+variable "jwt_private_key_file" {
+  description = "Defines the path to the private key to use to sign the jwt auth token (optional)"
+}
+
+variable "jwt_public_key_file" {
+  description = "Defines the path to the public key to verify the jwt auth token (optional)"
+}
+
+variable "jwt_ttl" {
+  description = "Defines the ttl of the jwt auth token(optional)"
+}

--- a/terraform/modules/ignition/ignition.tf
+++ b/terraform/modules/ignition/ignition.tf
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 data "ignition_config" "main" {
-  files = [
+  files = concat([
     data.ignition_file.eco-config.rendered,
     data.ignition_file.eco-ca.rendered,
     data.ignition_file.eco-crt.rendered,
@@ -21,7 +21,10 @@ data "ignition_config" "main" {
     data.ignition_file.eco-health.rendered,
     data.ignition_file.e.rendered,
     data.ignition_file.telegraf-config.rendered,
-  ]
+    ], var.eco_jwt_enabled ? [
+    data.ignition_file.eco-jwt-private-key.rendered,
+    data.ignition_file.eco-jwt-public-key.rendered,
+  ] : [])
 
   systemd = [
     data.ignition_systemd_unit.docker.rendered,
@@ -172,6 +175,26 @@ data "ignition_file" "eco-health" {
 
   content {
     content = file("${path.module}/resources/eco-health.sh")
+  }
+}
+
+data "ignition_file" "eco-jwt-private-key" {
+  filesystem = "root"
+  path       = "/etc/eco/eco-jwt-key.private"
+  mode       = 420
+
+  content {
+    content = var.eco_jwt_private_key
+  }
+}
+
+data "ignition_file" "eco-jwt-public-key" {
+  filesystem = "root"
+  path       = "/etc/eco/eco-jwt-key.public"
+  mode       = 420
+
+  content {
+    content = var.eco_jwt_public_key
   }
 }
 

--- a/terraform/modules/ignition/output.tf
+++ b/terraform/modules/ignition/output.tf
@@ -28,3 +28,10 @@ output "eco_key_file" {
   value = "/etc/eco/eco.key"
 }
 
+output "eco_jwt_private_key_file" {
+  value = "/etc/eco/eco-jwt-key.private"
+}
+
+output "eco_jwt_public_key_file" {
+  value = "/etc/eco/eco-jwt-key.public"
+}

--- a/terraform/modules/ignition/variables.tf
+++ b/terraform/modules/ignition/variables.tf
@@ -53,3 +53,16 @@ variable "ignition_extra_config" {
   description = "Extra ignition configuration that will get appended to the default ECO config"
   default     = {}
 }
+
+variable "eco_jwt_private_key" {
+  description = "Defines the private key to use to sign the jwt auth token (optional)"
+}
+
+variable "eco_jwt_public_key" {
+  description = "Defines the private key to verify the jwt auth token (optional)"
+}
+
+variable "eco_jwt_enabled" {
+  description = "Defines whether the jwt auth token is enabled"
+  default     = false
+}

--- a/terraform/modules/tls/output.tf
+++ b/terraform/modules/tls/output.tf
@@ -39,3 +39,11 @@ output "acl_users_certs" {
 output "acl_users_keys" {
   value = var.enabled == "true" && var.generate_clients_cert == "true" ? tls_private_key.acl_users : []
 }
+
+output "jwt_private_key" {
+  value = var.enabled == "true" && var.enable_jwt_token ? join("", tls_private_key.jwt_key.*.private_key_pem) : ""
+}
+
+output "jwt_public_key" {
+  value = var.enabled == "true" && var.enable_jwt_token ? join("", tls_private_key.jwt_key.*.public_key_pem) : ""
+}

--- a/terraform/modules/tls/tls.tf
+++ b/terraform/modules/tls/tls.tf
@@ -182,3 +182,9 @@ resource "tls_locally_signed_cert" "acl_users" {
   }
 }
 
+resource "tls_private_key" "jwt_key" {
+  count = var.enabled == "true" && var.enable_jwt_token ? 1 : 0
+
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}

--- a/terraform/modules/tls/variables.tf
+++ b/terraform/modules/tls/variables.tf
@@ -32,3 +32,8 @@ variable "generate_clients_cert" {
 variable "eco_init_acl_users" {
   description = "Defines the list of ACL users for the etcd (optional)"
 }
+
+variable "enable_jwt_token" {
+  description = "Defines whether or not to create private/public key pairs to verify jwt tokens"
+  default     = false
+}

--- a/terraform/platforms/aws/iam.tf
+++ b/terraform/platforms/aws/iam.tf
@@ -29,15 +29,15 @@ data "template_file" "policy" {
   template = file("${path.module}/policy.json")
 
   vars = {
-    bucket = aws_s3_bucket.backups.bucket
-    kms_arn = aws_kms_key.key.arn
+    bucket     = aws_s3_bucket.backups.bucket
+    kms_arn    = aws_kms_key.key.arn
     config_arn = "arn:aws:s3:::${aws_s3_bucket.config.id}/${aws_s3_bucket_object.ignition_config.id}"
   }
 }
 
 resource "aws_iam_role_policy" "instances" {
-  name = var.name
-  role = aws_iam_role.instances.id
+  name   = var.name
+  role   = aws_iam_role.instances.id
   policy = data.template_file.policy.rendered
 }
 

--- a/terraform/platforms/aws/variables.tf
+++ b/terraform/platforms/aws/variables.tf
@@ -48,7 +48,7 @@ variable "vpc_id" {
 
 variable "route53_prefix" {
   description = "Defines the primary dns prefix for the Route53 entry"
-  default = "etcd"
+  default     = "etcd"
 }
 
 variable "route53_enabled" {


### PR DESCRIPTION
According to https://github.com/etcd-io/etcd/issues/9629#issuecomment-384641934
The simple auth token will be invalid if the membership changes, which is probably the reason we saw errors like 

```auth: invalid auth token: vRZOlzVDUUCdjkbP.0
 etcdserver: failed to revoke 463a791ababbfc2d ("auth: invalid auth token")
```

which prevents the lease entry from being moved in the etcd store.

This PR adds the support to enable the jwt auth token feature.