### PR TITLE
README.md: Add a paragraph to decribe the jwt-auth-token-config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ failures.
 -   _ACL support_: A user can configure the ACL of etcd by providing an **init-acl** config
     in the config file. See [init-acl.md](./docs/init-acl.md) for more information.
 
+-   _JWT auth token support_: JWT auth token can be enabled by specifying the
+    `jwt-auth-token-config` in the config file, similar to the etcd [-auth-token](https://etcd.io/docs/v3.3/op-guide/configuration/#--auth-token)
+    flag.
+    The JWT auth token is **HIGHLY** recommended for [production deployment](https://etcd.io/docs/v3.2/learning/auth_design/#two-types-of-tokens-simple-and-jwt),
+    especially when the **init-acl** config is also enabled, the JWT auth token can help
+    avoid the potential [invalid auth token issue](https://github.com/etcd-io/etcd/issues/9629).
+
 The operator and etcd cluster can be easily configured using a [YAML file]. The
 configuration notably includes clients/peers TLS encryption/authentication, with
 the ability to automatically generate self-signed certificates if encryption

--- a/docs/init-acl.md
+++ b/docs/init-acl.md
@@ -46,3 +46,11 @@ Allows the `read` permission on paths from `/foo1` to `/foo5`.
 The `users` section defines a list of users, each user can be assigned to multiple roles.
 Optionally, a password can be also set for the user.
 Without a password, etcd will checks the client's TLS cert and use the `CommonName (CN)` to authenticate the user.
+
+
+### JWT Auth Token
+
+It's **HIGHLY** recommended to enable the **JWT Auth Token** when the etcd authentication is turned on (e.g. when the **init-acl** config is set).
+The JWT token can help avoid the potential [invalid auth token issue](https://github.com/etcd-io/etcd/issues/9629), which would require an etcd reboot to fix it.
+See the [README](../README.md) or the [example config](../config.example.yaml) to find out how to configure the **JWT Auth Token**.
+More details about the JWT token v.s. simple token can be found [here](https://etcd.io/docs/v3.2/learning/auth_design/#two-types-of-tokens-simple-and-jwt).


### PR DESCRIPTION
Also add a section in the docs/init-acl.md to suggest turning on the jwt
auth config.