### PR TITLE
terraform/common.tf: Update the default eco image tag.

### DIFF
--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -35,7 +35,7 @@ variable "instance_ssh_keys" {
 
 variable "eco_image" {
   description = "Container image of ECO to use"
-  default     = "quay.io/quentin_m/etcd-cloud-operator:v3.4.13"
+  default     = "quay.io/quentin_m/etcd-cloud-operator:v3.4.13-a5b0635"
 }
 
 variable "telegraf_image" {

--- a/terraform/platforms/aws/README.md
+++ b/terraform/platforms/aws/README.md
@@ -54,7 +54,7 @@ load_balancer_security_group_ids = []
 metrics_security_group_ids = []
 
 # Container image of ECO to use.
-eco_image = "quay.io/quentin_m/etcd-cloud-operator:v3.4.4a"
+eco_image = "quay.io/quentin_m/etcd-cloud-operator:v3.4.13-a5b0635"
 # Defines whether etcd should expect TLS clients connections.
 eco_enable_tls = "true"
 # Defines whether etcd should expect client certificates for client connections.
@@ -128,7 +128,7 @@ module "eco" {
   load_balancer_security_group_ids = []
   metrics_security_group_ids       = []
 
-  eco_image                  = "quay.io/quentin_m/etcd-cloud-operator:v3.4.4a"
+  eco_image                  = "quay.io/quentin_m/etcd-cloud-operator:v3.4.13-a5b0635"
   eco_enable_tls             = "true"
   eco_require_client_certs   = "false"
   eco_snapshot_interval      = "30m"


### PR DESCRIPTION
The new build supports the jwt-auth-token-config which is optional.