### PR TITLE
Add a startupProbe to check node health

### DIFF
--- a/chart/etcd-cloud-operator/templates/statefulset.yaml
+++ b/chart/etcd-cloud-operator/templates/statefulset.yaml
@@ -38,6 +38,22 @@ spec:
             mountPath: /etc/eco
             readOnly: true
           env:
+          - name: ETCD_API
+            value: "3"
+          - name: ETCDCTL_INSECURE_SKIP_TLS_VERIFY
+            value: "true"
+          {{- if .Values.config.etcd.clientTransportSecurity.trustedCaFile }}
+          - name: ETCDCTL_CACERT
+            value: {{ .Values.config.etcd.clientTransportSecurity.trustedCaFile }}
+          {{- end }}
+          {{- if .Values.config.etcd.clientTransportSecurity.certFile }}
+          - name: ETCDCTL_CERT
+            value: {{ .Values.config.etcd.clientTransportSecurity.certFile }}
+          {{- end }}
+          {{- if .Values.config.etcd.clientTransportSecurity.keyFile }}
+          - name: ETCDCTL_KEY
+            value: {{ .Values.config.etcd.clientTransportSecurity.keyFile }}
+          {{- end }}
           - name: STATEFULSET_SERVICE_NAME
             value: {{ include "etcd-cloud-operator.fullname" . }}
           - name: STATEFULSET_NAME
@@ -74,6 +90,14 @@ spec:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 30
+          startupProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - /usr/local/bin/etcdctl --endpoints=${POD_IP}:2379 endpoint health
+            failureThreshold: {{ .Values.setupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.setupProbe.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/chart/etcd-cloud-operator/values.yaml
+++ b/chart/etcd-cloud-operator/values.yaml
@@ -8,6 +8,10 @@ service:
 # Used by the Pod disruption budget
 maxUnavailable: 30%
 
+setupProbe:
+  failureThreshold: 30
+  periodSeconds: 10
+
 persistence:
   enabled: false
   ## A manually managed Persistent Volume and Claim


### PR DESCRIPTION
Adds a startupProbe that runs `etcdctl endpoint health` against the
local etcd node to verify that etcd is fully up and running before
continuing.  This fixes the issue where a statefulset update or rolling
restart would take out the entire cluster.

Signed-off-by: Matt Wilder <me@partcyb.org>