### PR TITLE
Add user "etcd" to role "root" so that the default tls client works

### DIFF
--- a/pkg/operator/acl.go
+++ b/pkg/operator/acl.go
@@ -213,6 +213,14 @@ func (s *Operator) enableACL(ctx context.Context, config *etcd.ACLConfig) error 
 		return err
 	}
 
+	if _, err := s.etcdClient.UserAddWithOptions(ctx, "etcd", "", &clientv3.UserAddOptions{NoPassword: true}); err != nil {
+			return err
+	}
+
+	if _, err := s.etcdClient.UserGrantRole(ctx, "etcd", "root"); err != nil {
+			return err
+	}
+
 	if _, err := s.etcdClient.AuthEnable(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
The default [tls client](https://github.com/Quentin-M/etcd-cloud-operator/blob/ac1d785dc8b532c2d73a20a724fa693261020258/terraform/modules/tls/tls.tf#L117-L118) that is created with CN "etcd" is rendered invalid after auth is enabled via initACL configs.

A potential alternative to not merging this change is to configure terraform tfvars with something like
```
eco_init_acl_users = [
...
  {
    name = "etcd"
    roles = ["root"]
    password = ""
  }
]
```

However, this is not very obvious and people might expect their client tls certs to be working after auth is enabled.