### PR TITLE
ASG: gated rolling update with default triggers

### DIFF
--- a/terraform/platforms/aws/asg.tf
+++ b/terraform/platforms/aws/asg.tf
@@ -64,6 +64,14 @@ resource "aws_autoscaling_group" "main" {
   vpc_zone_identifier  = var.subnets_ids
   launch_configuration = aws_launch_configuration.main.name
 
+  dynamic "instance_refresh" {
+    for_each = var.instance_refresh_enabled ? [1] : []
+
+    content {
+      strategy = "Rolling"
+    }
+  }
+
   tags = [
     {
       key                 = "Name"

--- a/terraform/platforms/aws/variables.tf
+++ b/terraform/platforms/aws/variables.tf
@@ -87,3 +87,9 @@ variable "extra_tags" {
   description = "Extra tags to associated with any AWS resources."
   default     = {}
 }
+
+variable "instance_refresh_enabled" {
+  type = bool
+  description = "Defines whether the ASG gets an automated rolling update strategy for refreshing instances"
+  default = false
+}


### PR DESCRIPTION
To enable deploying changes in high velocity environments (like dev/test), extending the [ASG](https://registry.terraform.io/providers/hashicorp/aws/3.51.0/docs/resources/autoscaling_group#instance_refresh) to conditionally allow `instance_refresh`.

