### PR TITLE
Support additional DNS names for clients-server TLS cert

### DIFF
--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -188,6 +188,10 @@ variable "jwt_ttl" {
   default     = "10m"
 }
 
+variable "san_dns_names" {
+  description = "List of additional DNS names for which the server certificate has to be trusted"
+  default     = []
+}
 // Modules.
 
 module "tls" {
@@ -196,6 +200,7 @@ module "tls" {
   enabled               = var.eco_enable_tls
   ca                    = var.ca
   common_name           = local.advertise_address
+  san_dns_names         = var.san_dns_names
   generate_clients_cert = var.eco_require_client_certs
 
   eco_init_acl_users = var.eco_init_acl_users

--- a/terraform/modules/tls/tls.tf
+++ b/terraform/modules/tls/tls.tf
@@ -75,7 +75,7 @@ resource "tls_cert_request" "clients-server" {
     organization = "etcd"
   }
 
-  dns_names = [var.common_name]
+  dns_names = concat([var.common_name], var.san_dns_names)
 }
 
 resource "tls_locally_signed_cert" "clients-server" {

--- a/terraform/modules/tls/variables.tf
+++ b/terraform/modules/tls/variables.tf
@@ -25,6 +25,11 @@ variable "common_name" {
   description = "Defines the common name for the clients_server certificate."
 }
 
+variable "san_dns_names" {
+  description = "List of additional DNS names for which the server certificate has to be trusted"
+  type        = list(string)
+}
+
 variable "generate_clients_cert" {
   description = "Defines whether additional clients certificates should be generated in addition to server certificates"
 }


### PR DESCRIPTION
Sometimes it is desirable to have multiple DNS names to reach the same cluster. This adds support to specify a list of hostnames that the Server's client certs would include. Avoids the use of ETCDCTL_INSECURE_SKIP_TLS_VERIFY flag.