### PR TITLE
Avoid invalid cross-device link

### DIFF
--- a/pkg/providers/snapshot/file/file.go
+++ b/pkg/providers/snapshot/file/file.go
@@ -55,7 +55,7 @@ func (f *file) Configure(providerConfig snapshot.Config) error {
 }
 
 func (f *file) Save(r io.ReadCloser, metadata *snapshot.Metadata) error {
-	tmpF, err := ioutil.TempFile("", metadata.Filename())
+	tmpF, err := ioutil.TempFile(f.config.Dir, metadata.Filename())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When default system location for temporary files is on different device
than target dir for snapshot files the invalid cross-device link error
will stop process of renaming file. Create temporary file at the same
location where snapshot is stored.

For example running container with /var/lib/snapshot mounted to hostPath is causing error:

```
{"level":"error","ts":"2022-04-02T16:58:21.671Z","caller":"etcd/server.go:487","msg":"failed to snapshot","error":"failed to save snapshot: rename /tmp/test-etcd-0_0000000000001780_etcd.backup1173612115 /var/lib/snapshots/test-etcd-0_0000000000001780_etcd.backup: invalid cross-device link","stacktrace":"github.com/quentin-m/etcd-cloud-operator/pkg/etcd.(*Server).runSnapshotter\n\t/go/src/github.com/quentin-m/etcd-cloud-operator/pkg/etcd/server.go:487"}
```