### PR TITLE
Fix snapshot directory permission

### DIFF
--- a/pkg/providers/snapshot/file/file.go
+++ b/pkg/providers/snapshot/file/file.go
@@ -29,7 +29,10 @@ import (
 	"github.com/quentin-m/etcd-cloud-operator/pkg/providers/snapshot"
 )
 
-const filePermissions = 0600
+const (
+	filePermissions     = 0600
+	directoryPermission = 0700
+)
 
 func init() {
 	snapshot.Register("file", &file{})
@@ -48,7 +51,7 @@ func (f *file) Configure(providerConfig snapshot.Config) error {
 	if err := providers.ParseParams(providerConfig.Params, &f.config); err != nil {
 		return fmt.Errorf("invalid configuration: %v", err)
 	}
-	if err := os.MkdirAll(f.config.Dir, filePermissions); err != nil {
+	if err := os.MkdirAll(f.config.Dir, directoryPermission); err != nil {
 		return fmt.Errorf("invalid configuration: failed to create directory %q: %v", f.config.Dir, err)
 	}
 	return nil


### PR DESCRIPTION
Missing executable bit for owner of snapshot directory prevented
creating snapshot files.

```
{"level":"error","ts":"2022-07-21T13:21:38.612Z","caller":"etcd/server.go:490","msg":"failed to snapshot","error":"failed to save snapshot: open /var/lib/snapshots/etcd-2_0000000000000009_etcd.backup3390438042: permission denied","stacktrace":"github.com/quentin-m/etcd-cloud-operator/pkg/etcd.(*Server).runSnapshotter\n\texternal/etcd_cloud_operator/pkg/etcd/server.go:490"}
{"level":"error","ts":"2022-07-21T13:21:38.613Z","caller":"etcd/server.go:291","msg":"failed to write etcd snapshot out [written bytes: 0]","error":"meta 0 copy: io: read/write on closed pipe","stacktrace":"github.com/quentin-m/etcd-cloud-operator/pkg/etcd.(*Server).snapshot.func1\n\texternal/etcd_cloud_operator/pkg/etcd/server.go:291"}
```

```
ubuntu@ubuntu:~$ kubectl exec -it etcd-2 -- ls -l /var/lib/
total 0
drwx------ 3 1000 3000 20 Jul 21 13:16 etcd
drw------- 2 1000 3000  6 Jul 21 13:16 snapshots
```

with change proposed in commit:

```
{"level":"info","ts":"2022-07-21T13:47:12.388Z","caller":"etcd/server.go:241","msg":"snapshot \"etcd-2_0000000000000009_etcd.backup\" saved successfully in 3.360749ms (0.02 MB)"}
```

```
ubuntu@ubuntu:~$ kubectl exec etcd-2 -- ls -l /var/lib/
total 0
drwx------ 3 1000 3000 20 Jul 21 13:42 etcd
drwx------ 2 1000 3000 58 Jul 21 13:47 snapshots
```