### PR TITLE
allow to configure etcd server limit max-request-bytes

### DIFF
--- a/docs/docker-testing/config.yaml
+++ b/docs/docker-testing/config.yaml
@@ -12,6 +12,7 @@ eco:
       peer-client-cert-auth: false
     auto-compaction-mode: periodic
     auto-compaction-retention: "0"
+    max-request-bytes: 4194304
   asg:
     provider: docker
     size: 3

--- a/pkg/etcd/misc.go
+++ b/pkg/etcd/misc.go
@@ -49,6 +49,7 @@ type EtcdConfiguration struct {
 	AutoCompactionRetention string              `yaml:"auto-compaction-retention"`
 	InitACL                 *ACLConfig          `yaml:"init-acl,omitempty"`
 	JWTAuthTokenConfig      *JWTAuthTokenConfig `yaml:"jwt-auth-token-config,omitempty"`
+	MaxRequestBytes         uint                `yaml:"max-request-bytes,omitempty"`
 }
 
 type SecurityConfig struct {

--- a/pkg/etcd/server.go
+++ b/pkg/etcd/server.go
@@ -59,6 +59,7 @@ type ServerConfig struct {
 	UnhealthyMemberTTL      time.Duration
 	AutoCompactionMode      string
 	AutoCompactionRetention string
+	MaxRequestBytes         uint
 
 	// Optional, used in {Seed, Join} to periodically save snapshots.
 	SnapshotProvider snapshot.Provider
@@ -355,6 +356,9 @@ func (c *Server) startServer(ctx context.Context) error {
 			c.cfg.JWTAuthTokenConfig.PublicKeyFile,
 			c.cfg.JWTAuthTokenConfig.SignMethod,
 			c.cfg.JWTAuthTokenConfig.TTL)
+	}
+	if c.cfg.MaxRequestBytes != 0 {
+		etcdCfg.MaxRequestBytes = c.cfg.MaxRequestBytes
 	}
 
 	// Start the server.

--- a/pkg/operator/misc.go
+++ b/pkg/operator/misc.go
@@ -123,7 +123,7 @@ func fetchStatuses(httpClient *http.Client, etcdClient *etcd.Client, asgInstance
 func fetchStatus(httpClient *http.Client, instance asg.Instance) (*status, error) {
 	var st = status{
 		instance: instance,
-		State: "UNKNOWN",
+		State:    "UNKNOWN",
 		Revision: 0,
 	}
 
@@ -149,7 +149,7 @@ func serverConfig(cfg Config, asgSelf asg.Instance, snapshotProvider snapshot.Pr
 		DataQuota:               cfg.Etcd.BackendQuota,
 		AutoCompactionMode:      cfg.Etcd.AutoCompactionMode,
 		AutoCompactionRetention: cfg.Etcd.AutoCompactionRetention,
-		BindAddress:			 asgSelf.BindAddress(),
+		BindAddress:             asgSelf.BindAddress(),
 		PublicAddress:           stringOverride(asgSelf.Address(), cfg.Etcd.AdvertiseAddress),
 		PrivateAddress:          asgSelf.Address(),
 		ClientSC:                cfg.Etcd.ClientTransportSecurity,
@@ -159,6 +159,7 @@ func serverConfig(cfg Config, asgSelf asg.Instance, snapshotProvider snapshot.Pr
 		SnapshotInterval:        cfg.Snapshot.Interval,
 		SnapshotTTL:             cfg.Snapshot.TTL,
 		JWTAuthTokenConfig:      cfg.Etcd.JWTAuthTokenConfig,
+		MaxRequestBytes:         cfg.Etcd.MaxRequestBytes,
 	}
 }
 


### PR DESCRIPTION
we need it for large CRDs like e.g. trivy-operator scan results for very vulnerable workloads: https://github.com/aquasecurity/trivy-operator/issues/441